### PR TITLE
Adjust default append behavior, provide for blacklist

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 2.2.6
 Date: ????
   Changes:
+    - Adjusted behavior of setting description default appending to allow for existing localised descriptions, and added a blacklist to ignore specified sets of mod settings
 ---------------------------------------------------------------------------------------------------
 Version: 2.2.5
 Date: 2020-11-25

--- a/settings-final-fixes.lua
+++ b/settings-final-fixes.lua
@@ -7,16 +7,49 @@
     "title": "Noxys Extra Settings Info",
     "author": "Noxy",
 --]]
+
+-- Setting prefixs to check for and then ignore
+local mod_settings_blacklist = {
+    "arachnophobia",
+    "vanillaLoaders",
+    "reskins-angels",
+    "reskins-bobs",
+    "reskins-compatibility",
+    "reskins-library",
+}
+
+-- Append defaults to bool settings
 if data.raw['bool-setting'] then
+    -- For every setting in 'bool-setting'
     for _, v in pairs(data.raw['bool-setting']) do
-        if v.default_value ~= nil then
-            v.localised_description = {'picker-extra-settings-info.merge', {'mod-setting-description.' .. v.name}, '\n\n' .. 'Default: ' .. tostring(v.default_value)}
+        -- Check if the setting is blacklisted
+        for _, s in pairs(mod_settings_blacklist) do
+            if string.find(v.name, s, 1, true) then goto continue end -- If true, setting is blacklisted, do nothing
         end
+
+        -- Append default to setting description, checking if localised_description was set already
+        if v.default_value ~= nil then
+            if v.localised_description then
+                v.localised_description = {'picker-extra-settings-info.merge', v.localised_description, '\n\n' .. 'Default: ' .. tostring(v.default_value)}
+            else
+                v.localised_description = {'picker-extra-settings-info.merge', {'mod-setting-description.' .. v.name}, '\n\n' .. 'Default: ' .. tostring(v.default_value)}
+            end
+        end
+
+        ::continue::
     end
 end
+
+-- Append defaults to int/double settings
 for _, s in pairs {'int-setting', 'double-setting'} do
     if data.raw[s] then
         for _, v in pairs(data.raw[s]) do
+            -- Check if the setting is blacklisted
+            for _, s in pairs(mod_settings_blacklist) do
+                if string.find(v.name, s, 1, true) then goto continue end -- If true, setting is blacklisted, do nothing
+            end
+
+            -- Construct table of min/max/default values
             local t = {}
             if v.minimum_value ~= nil then
                 table.insert(t, 'Minimum: ' .. v.minimum_value)
@@ -27,14 +60,30 @@ for _, s in pairs {'int-setting', 'double-setting'} do
             if v.maximum_value ~= nil then
                 table.insert(t, 'Maximum: ' .. v.maximum_value)
             end
+
+            -- Append default to setting description, checking if localised_description was set already
             if #t then
-                v.localised_description = {'picker-extra-settings-info.merge', {'mod-setting-description.' .. v.name}, '\n\n' .. table.concat(t, ', ')}
+                if v.localised_description then
+                    v.localised_description = {'picker-extra-settings-info.merge', v.localised_description, '\n\n' .. table.concat(t, ', ')}
+                else
+                    v.localised_description = {'picker-extra-settings-info.merge', {'mod-setting-description.' .. v.name}, '\n\n' .. table.concat(t, ', ')}
+                end
             end
+
+            ::continue::
         end
     end
 end
+
+-- Append defaults to string settings
 if data.raw['string-setting'] then
     for _, v in pairs(data.raw['string-setting']) do
+        -- Check if the setting is blacklisted
+        for _, s in pairs(mod_settings_blacklist) do
+            if string.find(v.name, s, 1, true) then goto continue end -- If true, setting is blacklisted, do nothing
+        end
+
+        -- Construct table of defaults/permissions
         local t = {}
         if v.default_value ~= nil then
             table.insert(t, 'Default: "' .. v.default_value .. '"')
@@ -44,8 +93,16 @@ if data.raw['string-setting'] then
         elseif v.allow_blank == false then
             table.insert(t, 'Disallows blank')
         end
+
+        -- Append default to setting description, checking if localised_description was set already
         if #t then
-            v.localised_description = {'picker-extra-settings-info.merge', {'mod-setting-description.' .. v.name}, '\n\n' .. table.concat(t, ', ')}
+            if v.localised_description then
+                v.localised_description = {'picker-extra-settings-info.merge', v.localised_description, '\n\n' .. table.concat(t, ', ')}
+            else
+                v.localised_description = {'picker-extra-settings-info.merge', {'mod-setting-description.' .. v.name}, '\n\n' .. table.concat(t, ', ')}
+            end
         end
+
+        ::continue::
     end
 end

--- a/settings-final-fixes.lua
+++ b/settings-final-fixes.lua
@@ -8,7 +8,7 @@
     "author": "Noxy",
 --]]
 
--- Setting prefixs to check for and then ignore
+-- Setting prefixes to check for and then ignore
 local mod_settings_blacklist = {
     "arachnophobia",
     "vanillaLoaders",

--- a/settings-final-fixes.lua
+++ b/settings-final-fixes.lua
@@ -23,8 +23,8 @@ if data.raw['bool-setting'] then
     -- For every setting in 'bool-setting'
     for _, v in pairs(data.raw['bool-setting']) do
         -- Check if the setting is blacklisted
-        for _, s in pairs(mod_settings_blacklist) do
-            if string.find(v.name, s, 1, true) then goto continue end -- If true, setting is blacklisted, do nothing
+        for _, setting in pairs(mod_settings_blacklist) do
+            if string.find(v.name, setting, 1, true) then goto continue end -- If true, setting is blacklisted, do nothing
         end
 
         -- Append default to setting description, checking if localised_description was set already
@@ -45,8 +45,8 @@ for _, s in pairs {'int-setting', 'double-setting'} do
     if data.raw[s] then
         for _, v in pairs(data.raw[s]) do
             -- Check if the setting is blacklisted
-            for _, s in pairs(mod_settings_blacklist) do
-                if string.find(v.name, s, 1, true) then goto continue end -- If true, setting is blacklisted, do nothing
+            for _, setting in pairs(mod_settings_blacklist) do
+                if string.find(v.name, setting, 1, true) then goto continue end -- If true, setting is blacklisted, do nothing
             end
 
             -- Construct table of min/max/default values
@@ -79,8 +79,8 @@ end
 if data.raw['string-setting'] then
     for _, v in pairs(data.raw['string-setting']) do
         -- Check if the setting is blacklisted
-        for _, s in pairs(mod_settings_blacklist) do
-            if string.find(v.name, s, 1, true) then goto continue end -- If true, setting is blacklisted, do nothing
+        for _, setting in pairs(mod_settings_blacklist) do
+            if string.find(v.name, setting, 1, true) then goto continue end -- If true, setting is blacklisted, do nothing
         end
 
         -- Construct table of defaults/permissions


### PR DESCRIPTION
I've expanded the functionality of the routine that runs in settings-final-fixes to append default values to account for the possibility that `localised_description` has already been set. This fixes the bug reported in issue #13. 

Additionally I've added logic to provide for search terms to check for in setting names in order to exclude them from the append routine. Currently I've excluded the mods that I maintain that include their defaults in the setting description already and do not need to be serviced.